### PR TITLE
add build turbo GH action to use across workflows

### DIFF
--- a/.github/actions/build-debug-turborepo/action.yml
+++ b/.github/actions/build-debug-turborepo/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: bash
       run: |
         cd cli
-        make shim
+        make turbo
         cd ..
     - name: Strip Turborepo binary
       shell: bash

--- a/.github/actions/build-debug-turborepo/action.yml
+++ b/.github/actions/build-debug-turborepo/action.yml
@@ -1,0 +1,43 @@
+name: "Turborepo Build Debug"
+description: "Builds debug version of turborepo"
+inputs:
+  target:
+    description: "Compilation target"
+    required: true
+  github-token:
+    description: "GitHub token. You can pass secrets.GITHUB_TOKEN"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: "Setup Node"
+      uses: ./.github/actions/setup-node
+    - name: "Setup Go"
+      uses: ./.github/actions/setup-go
+      with:
+        github-token: ${{ inputs.github-token }}
+    - name: "Setup Rust toolchain"
+      uses: actions-rs/toolchain@v1
+      if: ${{ inputs.target != 'windows' }}
+    - name: "Set Windows default host to MingW"
+      if: ${{ inputs.target == 'windows' }}
+      shell: bash
+      run: rustup set default-host x86_64-pc-windows-gnu && rustup show
+    - name: "Setup Rust Cache"
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: debug-${{ inputs.target }}
+    - name: Build Turborepo
+      shell: bash
+      run: |
+        cd cli
+        make shim
+        cd ..
+    - name: Strip Turborepo binary
+      shell: bash
+      run: strip target/debug/turbo.exe
+      if: ${{ inputs.target == 'windows' }}
+    - name: Strip Turborepo binary
+      shell: bash
+      run: strip target/debug/turbo
+      if: ${{ inputs.target != 'windows' }}

--- a/.github/workflows/pr-go-e2e-filtered.yml
+++ b/.github/workflows/pr-go-e2e-filtered.yml
@@ -38,4 +38,5 @@ jobs:
           target: ${{ matrix.os.name }}
 
       - name: E2E Tests
-        run: pnpm -- turbo run e2e --filter=cli
+        # Turbo has already been built in previous step, no need to rebuild
+        run: pnpm -- turbo-prebuilt run e2e-prebuilt --filter=cli

--- a/.github/workflows/pr-go-e2e-filtered.yml
+++ b/.github/workflows/pr-go-e2e-filtered.yml
@@ -18,18 +18,24 @@ on:
 jobs:
   test:
     timeout-minutes: 15
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - name: ubuntu
+            runner: ubuntu-latest
+          - name: macos
+            runner: macos-latest
+          - name: windows
+            runner: windows-latest
 
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-node
-      - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/build-debug-turborepo
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          target: ${{ matrix.os.name }}
 
       - name: E2E Tests
         run: pnpm -- turbo run e2e --filter=cli

--- a/.github/workflows/pr-go-e2e-filtered.yml
+++ b/.github/workflows/pr-go-e2e-filtered.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-go-integration-filtered.yml
+++ b/.github/workflows/pr-go-integration-filtered.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-go-integration-filtered.yml
+++ b/.github/workflows/pr-go-integration-filtered.yml
@@ -18,26 +18,20 @@ on:
 jobs:
   test:
     timeout-minutes: 15
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os:
+          - name: ubuntu
+            runner: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-node
-      - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/build-debug-turborepo
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Setup rust
-        uses: actions-rs/toolchain@v1
-
-      - name: Setup rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: test
+          target: ${{ matrix.os.name }}
 
       - name: Cache Prysk
         id: cache-prysk

--- a/.github/workflows/pr-js-tests-filtered.yml
+++ b/.github/workflows/pr-js-tests-filtered.yml
@@ -18,11 +18,15 @@ on:
 jobs:
   test:
     timeout-minutes: 30
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os:
+          - name: ubuntu
+            runner: ubuntu-latest
+          - name: macos
+            runner: macos-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -41,10 +45,10 @@ jobs:
           else
             git fetch --no-tags --prune --progress --depth=2
           fi
-      - uses: ./.github/actions/setup-node
-      - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/build-debug-turborepo
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          target: ${{ matrix.os.name }}
 
       # Note this runs nothing on push since event is push and not pull_request and ...[] matches nothing?
       # For push we should just do ..[HEAD^]

--- a/.github/workflows/pr-js-tests-filtered.yml
+++ b/.github/workflows/pr-js-tests-filtered.yml
@@ -34,6 +34,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/build-debug-turborepo
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          target: ${{ matrix.os.name }}
       - name: checkout
         # We want to fetch all of the commits in PR and the commit it's based on
         # If this isn't a PR, then this is a push and we check against the previous commit
@@ -45,10 +49,6 @@ jobs:
           else
             git fetch --no-tags --prune --progress --depth=2
           fi
-      - uses: ./.github/actions/build-debug-turborepo
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          target: ${{ matrix.os.name }}
 
       # Note this runs nothing on push since event is push and not pull_request and ...[] matches nothing?
       # For push we should just do ..[HEAD^]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,17 +168,23 @@ jobs:
     needs: determine_jobs
     if: needs.determine_jobs.outputs.go == 'true'
     timeout-minutes: 15
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - name: ubuntu
+            runner: ubuntu-latest
+          - name: macos
+            runner: macos-latest
+          - name: windows
+            runner: windows-latest
 
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-node
-      - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/build-debug-turborepo
         with:
+          target: ${{ matrix.os.name }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - run: pnpm -- turbo run test --filter=cli --color
@@ -192,30 +198,46 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os:
+          - name: ubuntu
+            runner: ubuntu-latest
+          - name: macos
+            runner: macos-latest
         manager: [yarn, npm]
         example: [with-yarn, with-npm, non-monorepo]
         include:
-          - os: ubuntu-latest
+          - os:
+              name: ubuntu
+              runner: ubuntu-latest
             manager: pnpm
             example: basic
-          - os: macos-latest
+          - os:
+              name: macos
+              runner: macos-latest
             manager: pnpm
             example: basic
-          - os: ubuntu-latest
+          - os:
+              name: ubuntu
+              runner: ubuntu-latest
             manager: pnpm
             example: kitchen-sink
-          - os: macos-latest
+          - os:
+              name: macos
+              runner: macos-latest
             manager: pnpm
             example: kitchen-sink
-          - os: ubuntu-latest
+          - os:
+              name: ubuntu
+              runner: ubuntu-latest
             manager: pnpm
             example: with-svelte
-          - os: macos-latest
+          - os:
+              name: macos
+              runner: macos-latest
             manager: pnpm
             example: with-svelte
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runner }}
     steps:
       # Used by scripts/check-examples.sh
       - name: Install Sponge
@@ -230,9 +252,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
+      - name: Build Turborepo
+        uses: ./.github/actions/build-debug-turborepo
         with:
+          target: ${{ matrix.os.name }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Setup Pnpm
@@ -895,10 +918,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-node
-
-      - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/build-debug-turborepo
         with:
+          target: ubuntu
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Format check

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -78,6 +78,11 @@ corepack:
 e2e: corepack install turbo
 	node -r esbuild-register scripts/e2e/e2e.ts
 
+# Expects turbo to be built and up to date
+# Only should be used by CI
+e2e-prebuilt: corepack install
+	node -r esbuild-register scripts/e2e/e2e.ts
+
 cmd/turbo/version.go: ../version.txt
 	# Update this atomically to avoid issues with this being overwritten during use
 	node -e 'console.log(`package main\n\nconst turboVersion = "$(TURBO_VERSION)"`)' > cmd/turbo/version.go.txt

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,6 +7,7 @@
     "build": "make",
     "test": "make test-go",
     "e2e": "make e2e",
+    "e2e-prebuilt": "make e2e-prebuilt",
     "publish": "make publish-all",
     "format": "make fmt-go",
     "lint": "make lint-go",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format:toml": "taplo format",
     "lint": "eslint . --ext js,jsx,ts,tsx",
     "turbo": "cd cli && make turbo && cd .. && node turbow.js",
+    "turbo-prebuilt": "node turbow.js",
     "docs": "pnpm -- turbo run dev --filter=docs --no-cache",
     "run-example": "./scripts/run-example.sh"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -70,6 +70,16 @@
         "shim/**/*.rs"
       ]
     },
+    "cli#e2e-prebuilt": {
+      "outputs": [],
+      "inputs": [
+        "cli/**/*.go",
+        "cli/go.mod",
+        "cli/go.sum",
+        "cli/scripts/e2e/e2e.ts",
+        "shim/**/*.rs"
+      ]
+    },
     "cli#integration-tests": {
       "outputs": []
     },


### PR DESCRIPTION
Add a new action that correctly builds the shim on windows and switch over all workflows to use this so we only need to alter it in one place. 

Didn't do any fancy passing of artifacts so we are building on every workflow, but hopefully this makes the PR cleaner.